### PR TITLE
Ft add sales #161203507

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ from flask import Flask
 from instance.config import app_config
 from app.views.authentication import authentication
 from app.views.products import product
+from api.views.sales import sale
 
 
 def create_app(config):
@@ -16,5 +17,6 @@ def create_app(config):
 
     app.register_blueprint(authentication)
     app.register_blueprint(product)
+    app.register_blueprint(sale)
 
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask import Flask
 from instance.config import app_config
 from app.views.authentication import authentication
 from app.views.products import product
-from api.views.sales import sale
+from app.views.sales import sale
 
 
 def create_app(config):

--- a/app/views/sales.py
+++ b/app/views/sales.py
@@ -1,0 +1,31 @@
+import datetime
+from flask import request, jsonify, Blueprint
+from ..models import sales_model
+from ..models.sales_model import SALES_DICT
+
+sale = Blueprint('sale', __name__, url_prefix='/api/v1')
+
+sale_object = sales_model.Sale()
+
+
+@sale.route('/sales', methods=['POST'])
+def post_sales():
+    """Endpoint for only attendant to post a sale"""
+    data = request.get_json()
+    if not data:
+        return jsonify({"message": "Fields cannot be empty"}), 400
+    item_count = data.get("items_count")
+    total_amount = data.get("total_amount")
+    created_by = "username"
+    now = datetime.datetime.now()
+    date_created = now
+    sale_id = len(SALES_DICT)
+
+    salesinfo = [item_count, total_amount]
+    for i in salesinfo:
+        if i is None or not i:
+            return jsonify({"message": "Items_count and total_amount fields can't be empty"}), 206
+
+    response = jsonify(sale_object.put(sale_id, date_created, created_by, item_count, total_amount))
+    response.status_code = 201
+    return response

--- a/tests/test_sales.py
+++ b/tests/test_sales.py
@@ -1,0 +1,94 @@
+import json
+from .base_test import BaseTestCase
+
+
+class TestSales(BaseTestCase):
+
+    def test_post_sales(self):
+        """Only an attendant can post sales"""
+        with self.client:
+            # Register an attendant
+            self.client.post(
+                '/api/v1/auth/register',
+                data=json.dumps(dict(
+                    name="leticia",
+                    email="ticia@gmail.com",
+                    role="attendant",
+                    username="ticia",
+                    password="1234",
+                    confirm_password="1234"
+                )),
+                content_type='application/json'
+            )
+            # Register admin
+            self.client.post(
+                '/api/v1/auth/register',
+                data=json.dumps(dict(
+                    name="leticia",
+                    email="ticia@gmail.com",
+                    role="admin",
+                    username="ticia",
+                    password="1234",
+                    confirm_password="1234"
+                )),
+                content_type='application/json'
+            )
+            # login admin
+            login_admin_response = self.client.post(
+                '/api/v1/auth/login',
+                data=json.dumps(dict(
+                    username="ticia",
+                    password="1234"
+
+                )),
+                content_type='application/json'
+            )
+
+            # login the attendant
+            login_response = self.client.post(
+                '/api/v1/auth/login',
+                data=json.dumps(dict(
+                    username="ticia",
+                    password="1234"
+
+                )),
+                content_type='application/json'
+            )
+
+            # Test successful post of a sale
+            response = self.client.post(
+                '/api/v1/sales',
+                data=json.dumps(dict(
+                    items_count=4,
+                    total_amount=5000
+                )),
+                content_type='application/json'
+            )
+
+            response_data = json.loads(response.data)
+            self.assertEqual("A sale has been created successfully", response_data["message"])
+            self.assertEqual(response.status_code, 201)
+
+            # Test sale data can't be empty
+            responsed = self.client.post(
+                '/api/v1/sales',
+                data=json.dumps(dict()
+                                ),
+                content_type='application/json'
+            )
+            response_datad = json.loads(responsed.data)
+            self.assertEqual("Fields cannot be empty", response_datad["message"])
+            self.assertEqual(responsed.status_code, 400)
+            # Test some missing fields
+            responsee = self.client.post(
+                '/api/v1/sales',
+                data=json.dumps(dict(
+                    items_count="",
+                    total_amount=5000
+                )),
+                content_type='application/json'
+            )
+
+            response_datae = json.loads(responsee.data)
+            self.assertEqual("Items_count and total_amount fields can't be empty", response_datae["message"])
+            self.assertEqual(responsee.status_code, 206)


### PR DESCRIPTION
#### What this PR does
Attendant can add sales orders 

#### Description of Task to be completed:
On sending POST request to the endpoints appropriate response should be received

#### How to manually test
On postman on route `POST /api/v1/sales`

#### Relevant story
#161203507- Store attendant should be able to add a sale order